### PR TITLE
Issue #7885 Don't raise error if response is 416

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -203,9 +203,13 @@ module Vagrant
           @logger.warn("Downloader exit code: #{result.exit_code}")
           parts    = result.stderr.split(/\n*curl:\s+\(\d+\)\s*/, 2)
           parts[1] ||= ""
-          raise Errors::DownloaderError,
-            code: result.exit_code,
-            message: parts[1].chomp
+          if parts[1].include? "416"
+            # All good actually. 416 means there is no mory bytes to download
+          else
+            raise Errors::DownloaderError,
+              code: result.exit_code,
+              message: parts[1].chomp
+          end
         end
 
         result


### PR DESCRIPTION
Vagrant downloader should handle response codes appropriately. HTTP response code 416 means that the requested bytes are out of range, which in case of `curl --continue-at` or `wget --continue` means that the entire file has already been downloaded.

The chosen place for patch is justified by the fact that we should not raise ANY error if response code is 416.